### PR TITLE
RST-23: Upgrade Mongoose to 5.2.x, closes #23

### DIFF
--- a/structure/app.js
+++ b/structure/app.js
@@ -12,7 +12,7 @@ var config = require('./config');
 var router = require('./routes');
 
 // Connect to Mongodb
-mongoose.connect(config.MONGODB_URL);
+mongoose.connect(config.MONGODB_URL, { useNewUrlParser: true });
 // Listen to connection event
 mongoose.connection.on('connected', function mongodbConnectionListener(err) {
     debug('Mongodb connected successfully');

--- a/templates/_package.json.template
+++ b/templates/_package.json.template
@@ -25,7 +25,7 @@
     "express-validator": "^3.1.2",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
-    "mongoose": "^4.8.1"
+    "mongoose": "^5.2.0"
   },
   "devDependencies": {
     "apidoc": "^0.17.5",


### PR DESCRIPTION
Upgrade Mongoose to 5.2.x to use MongoDB 4.0+