### PR TITLE
feat: improve the CLI setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 An opinionated ExpressJs based REST API generator.
 
+## CLI usage
+
+Generate an application with either the explicit command or the original
+settings-file shorthand:
+
+```sh
+resta generate settings.json
+resta settings.json
+```
+
+Create a settings file interactively:
+
+```sh
+resta init
+resta init custom-settings.json
+```
+
+The initializer uses the generator's defaults to keep the resulting file small.
+It will not overwrite an existing file without confirmation.
+
+```sh
+resta --help
+resta --version
+```
+
+The original `restaculous` command remains available as a compatibility alias.
+
 ## CLI development and tests
 
 CLI development requires Node.js 24 or newer. The repository includes an

--- a/app.js
+++ b/app.js
@@ -13,6 +13,8 @@ import * as testGenerator from "./generators/test.js";
 import * as validatorGenerator from "./generators/validator.js";
 import * as formatter from "./runners/format.js";
 import * as linter from "./runners/lint.js";
+import { HELP, parseCliArguments, VERSION } from "./cli/arguments.js";
+import { runInit } from "./cli/init.js";
 import { STATUS } from "./config/index.js";
 import { loadSettings } from "./cli/settings.js";
 import { runWorkflow } from "./cli/workflow.js";
@@ -46,21 +48,32 @@ const completionMessages = {
 };
 
 async function main() {
-  const filePath = process.argv[2];
-
-  if (!filePath) {
-    console.log(
-      chalk.yellow("%s Warning: settings.json file not provided!"),
-      STATUS.warning
-    );
-    return;
-  }
-
   try {
-    const settings = await loadSettings(filePath);
+    const options = parseCliArguments();
+
+    if (options.command === "help") {
+      console.log(HELP.trimEnd());
+      return;
+    }
+    if (options.command === "version") {
+      console.log(VERSION);
+      return;
+    }
+    if (options.command === "init") {
+      const result = await runInit({ settingsPath: options.settingsPath });
+      console.log(result.created
+        ? chalk.green(`${STATUS.success} Created ${result.path}`)
+        : chalk.yellow(`${STATUS.warning} Settings file was not changed`));
+      return;
+    }
+
+    const settings = await loadSettings(options.settingsPath);
     await runWorkflow(settings, services, reportStageComplete);
   } catch (error) {
     console.error(chalk.red(`${STATUS.error} ${error.message}`));
+    if (error.name === "CliUsageError") {
+      console.error("Run resta --help for usage.");
+    }
     process.exitCode = 1;
   }
 }

--- a/cli/arguments.js
+++ b/cli/arguments.js
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+const packageInfo = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+);
+
+export const VERSION = packageInfo.version;
+
+export const HELP = `Rest-a-culous
+
+Generate an opinionated Express and Mongoose REST API.
+
+Usage:
+  resta <settings-file>
+  resta generate <settings-file>
+  resta init [settings-file]
+  resta --help
+  resta --version
+
+Commands:
+  generate    Generate an API from a validated settings file
+  init        Interactively create a settings file
+
+Options:
+  -h, --help       Show this help message
+  -v, --version    Show the installed version
+
+The original restaculous command remains available as an alias.
+`;
+
+export class CliUsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CliUsageError";
+  }
+}
+
+export function parseCliArguments(argv = process.argv.slice(2)) {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        help: { type: "boolean", short: "h" },
+        version: { type: "boolean", short: "v" }
+      },
+      strict: true
+    });
+  } catch (error) {
+    throw new CliUsageError(error.message, { cause: error });
+  }
+
+  if (parsed.values.help) {
+    return { command: "help" };
+  }
+  if (parsed.values.version) {
+    return { command: "version" };
+  }
+
+  const [command, argument, ...extra] = parsed.positionals;
+  if (!command) {
+    return { command: "help" };
+  }
+  if (extra.length > 0) {
+    throw new CliUsageError(`Unexpected arguments: ${extra.join(" ")}`);
+  }
+
+  if (command === "generate") {
+    if (!argument) {
+      throw new CliUsageError("The generate command requires a settings file.");
+    }
+    return { command, settingsPath: argument };
+  }
+
+  if (command === "init") {
+    return { command, settingsPath: argument ?? "settings.json" };
+  }
+
+  if (argument) {
+    throw new CliUsageError(`Unknown command: ${command}`);
+  }
+
+  return { command: "generate", settingsPath: command };
+}

--- a/cli/init.js
+++ b/cli/init.js
@@ -1,0 +1,137 @@
+import { access, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+
+import { ACTIONS } from "../config/index.js";
+import { validateSettings } from "./settings.js";
+
+export async function runInit({
+  settingsPath = "settings.json",
+  cwd = process.cwd(),
+  input = process.stdin,
+  output = process.stdout,
+  ask
+} = {}) {
+  const prompts = ask ? null : createInterface({ input, output });
+  const prompt = ask ?? ((question) => prompts.question(question));
+
+  try {
+    const targetPath = path.resolve(cwd, settingsPath);
+
+    if (await fileExists(targetPath)) {
+      const overwrite = await askBoolean(
+        prompt,
+        `Overwrite ${targetPath}?`,
+        false
+      );
+      if (!overwrite) {
+        return { created: false, path: targetPath };
+      }
+    }
+
+    const settings = await createSettingsFromPrompts(prompt);
+    await writeFile(targetPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+    return { created: true, path: targetPath };
+  } finally {
+    prompts?.close();
+  }
+}
+
+export async function createSettingsFromPrompts(ask) {
+  const name = await askRequired(ask, "Application name: ");
+  const suggestedDirectory = `./${slugify(name)}`;
+  const directory = await askWithDefault(ask, "Output directory", suggestedDirectory);
+  const description = (await ask("Description (optional): ")).trim();
+  const author = (await ask("Author (optional): ")).trim();
+  const repositoryUrl = (await ask("Repository URL (optional): ")).trim();
+  const authentication = await askBoolean(ask, "Enable JWT authentication?", false);
+  const modelNames = parseList(await ask("Models, separated by commas (optional): "));
+  const models = [];
+
+  for (const modelName of modelNames) {
+    const attributes = parseAttributes(
+      await ask(`${modelName} attributes as name:type pairs (optional): `)
+    );
+    const routes = parseActions(
+      await askWithDefault(ask, `${modelName} CRUD routes`, ACTIONS.join(","))
+    );
+    const protectedRoutes = authentication
+      ? parseActions(await ask(`${modelName} protected routes (optional): `))
+      : [];
+
+    models.push({
+      name: capitalize(modelName),
+      attributes,
+      routes,
+      authentication: protectedRoutes
+    });
+  }
+
+  const settings = {
+    name,
+    directory,
+    ...(description && { description }),
+    ...(author && { author }),
+    ...(repositoryUrl && { repository: { type: "git", url: repositoryUrl } }),
+    ...(authentication && { authentication }),
+    ...(models.length && { models })
+  };
+
+  validateSettings(settings);
+  return settings;
+}
+
+async function askRequired(ask, label) {
+  while (true) {
+    const answer = (await ask(label)).trim();
+    if (answer) {
+      return answer;
+    }
+  }
+}
+
+async function askWithDefault(ask, label, defaultValue) {
+  const answer = (await ask(`${label} (${defaultValue}): `)).trim();
+  return answer || defaultValue;
+}
+
+async function askBoolean(ask, label, defaultValue) {
+  const hint = defaultValue ? "Y/n" : "y/N";
+  const answer = (await ask(`${label} [${hint}] `)).trim().toLowerCase();
+  if (!answer) {
+    return defaultValue;
+  }
+  return answer === "y" || answer === "yes";
+}
+
+function parseList(value) {
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function parseActions(value) {
+  return [...new Set(parseList(value).map((action) => action.toLowerCase()))];
+}
+
+function parseAttributes(value) {
+  return parseList(value).map((entry) => {
+    const [name, type = "String"] = entry.split(":").map((part) => part.trim());
+    return { name, type };
+  });
+}
+
+function capitalize(value) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function slugify(value) {
+  return value.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "zod": "^4.5.2"
       },
       "bin": {
+        "resta": "app.js",
         "restaculous": "app.js"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "app.js",
   "bin": {
+    "resta": "./app.js",
     "restaculous": "./app.js"
   },
   "directories": {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -20,19 +20,126 @@ import {
   validateSettings
 } from "../cli/settings.js";
 import { runWorkflow } from "../cli/workflow.js";
+import { runInit } from "../cli/init.js";
+import {
+  CliUsageError,
+  parseCliArguments,
+  VERSION
+} from "../cli/arguments.js";
 
 const projectDirectory = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
 
-test("CLI prints guidance when no settings file is provided", () => {
+test("CLI displays help when no command is provided", () => {
   const output = execFileSync(process.execPath, ["app.js"], {
     cwd: projectDirectory,
     encoding: "utf8"
   });
 
-  assert.match(output, /settings\.json file not provided/i);
+  assert.match(output, /Usage:/);
+  assert.match(output, /resta init/);
+});
+
+test("CLI displays help and version flags", () => {
+  const help = execFileSync(process.execPath, ["app.js", "--help"], {
+    cwd: projectDirectory,
+    encoding: "utf8"
+  });
+  const version = execFileSync(process.execPath, ["app.js", "--version"], {
+    cwd: projectDirectory,
+    encoding: "utf8"
+  });
+
+  assert.match(help, /Generate an opinionated Express and Mongoose REST API/);
+  assert.equal(version.trim(), VERSION);
+});
+
+test("package exposes resta with the original command as an alias", async () => {
+  const packageInfo = JSON.parse(
+    await readFile(path.join(projectDirectory, "package.json"), "utf8")
+  );
+
+  assert.equal(packageInfo.bin.resta, "./app.js");
+  assert.equal(packageInfo.bin.restaculous, "./app.js");
+});
+
+test("argument parser supports explicit and legacy generate commands", () => {
+  assert.deepEqual(parseCliArguments(["generate", "settings.json"]), {
+    command: "generate",
+    settingsPath: "settings.json"
+  });
+  assert.deepEqual(parseCliArguments(["settings.json"]), {
+    command: "generate",
+    settingsPath: "settings.json"
+  });
+});
+
+test("argument parser rejects invalid commands and options", () => {
+  assert.throws(
+    () => parseCliArguments(["generate"]),
+    CliUsageError
+  );
+  assert.throws(
+    () => parseCliArguments(["unknown", "value"]),
+    /Unknown command/
+  );
+  assert.throws(
+    () => parseCliArguments(["--unknown"]),
+    CliUsageError
+  );
+});
+
+test("CLI init creates a minimal validated settings file", async (t) => {
+  const fixtureDirectory = await mkdtemp(
+    path.join(tmpdir(), "restaculous-init-test-")
+  );
+  t.after(() => rm(fixtureDirectory, { recursive: true, force: true }));
+
+  const answers = [
+    "Movies API",
+    "",
+    "A generated movie API",
+    "",
+    "",
+    "n",
+    "Movie",
+    "title:String,year:Number",
+    ""
+  ];
+  const result = await runInit({
+    cwd: fixtureDirectory,
+    ask: async () => answers.shift()
+  });
+
+  const contents = JSON.parse(
+    await readFile(path.join(fixtureDirectory, "settings.json"), "utf8")
+  );
+  const settings = validateSettings(contents);
+
+  assert.equal(result.created, true);
+  assert.equal(contents.directory, "./movies-api");
+  assert.equal(settings.models[0].name, "Movie");
+  assert.equal(settings.models[0].attributes[1].type, "Number");
+});
+
+test("CLI init does not overwrite an existing settings file without confirmation", async (t) => {
+  const fixtureDirectory = await mkdtemp(
+    path.join(tmpdir(), "restaculous-init-test-")
+  );
+  t.after(() => rm(fixtureDirectory, { recursive: true, force: true }));
+
+  const settingsPath = path.join(fixtureDirectory, "settings.json");
+  await writeFile(settingsPath, "existing contents\n", "utf8");
+
+  const result = await runInit({
+    cwd: fixtureDirectory,
+    ask: async () => "n"
+  });
+
+  assert.equal(result.created, false);
+  assert.equal(await readFile(settingsPath, "utf8"), "existing contents\n");
 });
 
 test("CLI reports a missing settings file and exits unsuccessfully", () => {


### PR DESCRIPTION
- Add structured commands, flags, help, and version output
- Preserve shorthand settings-file generation for compatibility
- Add an interactive workflow for creating validated settings
- Protect existing settings files from accidental overwrites
- Introduce resta as the shorter primary CLI command
- Retain restaculous as a backward-compatible alias
- Document the updated generation and initialization workflows
- Expand coverage for commands, arguments, aliases, and initialization

Closes #75