### PR TITLE
feat(generated-app): isolate MongoDB test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Here is a [Gist](https://gist.github.com/tsega/b15307af018d49171dfdbde47f0d2d07)
   "config": [
     {"name": "HTTP_PORT", "value": 8000, "comment": "HTTP port"},
     {"name": "MONGODB_URL", "value":"mongodb://127.0.0.1:27017/[app-name]", "comment": "MongoDB URL"},
+    {"name": "TEST_MONGODB_URL", "value":"mongodb://127.0.0.1:27017/[app-name]-test", "comment": "MongoDB test URL"},
     {"name": "SALT_LENGTH", "value": 12, "comment": "Password hash rounds"},
     {"name": "JWT_KEY", "value":"change-me", "comment": "JWT signing secret"},
     {"name": "MAX_PAGE_SIZE", "value": 100, "comment": "Maximum search page size"},

--- a/cli/settings.js
+++ b/cli/settings.js
@@ -132,6 +132,11 @@ function defaultConfig(name) {
       value: `mongodb://127.0.0.1:27017/${databaseName}`,
       comment: "MongoDB connection URL"
     },
+    {
+      name: "TEST_MONGODB_URL",
+      value: `mongodb://127.0.0.1:27017/${databaseName}-test`,
+      comment: "MongoDB connection URL used only by tests"
+    },
     { name: "SALT_LENGTH", value: 12, comment: "Password hash rounds" },
     { name: "JWT_KEY", value: "change-me", comment: "JWT signing secret" },
     { name: "MAX_PAGE_SIZE", value: 100, comment: "Maximum search page size" },

--- a/structure/README.md
+++ b/structure/README.md
@@ -21,6 +21,7 @@ startup, then exits with a clear error if configuration is invalid.
 
 - `HTTP_PORT`: server port from 1 to 65535; defaults to `8000`
 - `MONGODB_URL`: required MongoDB connection URL
+- `TEST_MONGODB_URL`: required, separate MongoDB URL used only by tests
 - `SALT_LENGTH`: positive integer used for password hashing; defaults to `12`
 - `JWT_KEY`: required signing secret when authentication is generated
 - `MAX_PAGE_SIZE`: positive maximum number of search results; defaults to `100`
@@ -37,3 +38,11 @@ HTTP request events. Request logs contain only the method, path, status, and
 duration; request bodies, query values, headers, and connection strings are not
 logged. Internal errors are logged by the server but are not returned in
 production-style HTTP error responses.
+
+## Test database safety
+
+Tests connect exclusively through `TEST_MONGODB_URL`; they never fall back to
+`MONGODB_URL`. The test command refuses to run if the two URLs are equal. Test
+files run serially, and generated test data is removed from the test database
+before Mongoose disconnects. Always use a dedicated database because its data
+is intentionally disposable.

--- a/structure/test/setup.js
+++ b/structure/test/setup.js
@@ -2,12 +2,37 @@ import "dotenv/config";
 import mongoose from "mongoose";
 import { after, before } from "node:test";
 
-import { MONGODB_URL } from "../src/config/index.js";
+const testDatabaseUrl = required("TEST_MONGODB_URL");
+const applicationDatabaseUrl = process.env.MONGODB_URL?.trim();
+let connected = false;
+
+if (testDatabaseUrl === applicationDatabaseUrl) {
+  throw new Error(
+    "Unsafe test configuration: TEST_MONGODB_URL must differ from MONGODB_URL"
+  );
+}
 
 before(async () => {
-  await mongoose.connect(MONGODB_URL);
+  await mongoose.connect(testDatabaseUrl);
+  connected = true;
 });
 
 after(async () => {
-  await mongoose.disconnect();
+  if (!connected) {
+    return;
+  }
+
+  try {
+    await mongoose.connection.dropDatabase();
+  } finally {
+    await mongoose.disconnect();
+  }
 });
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required test environment variable: ${name}`);
+  }
+  return value;
+}

--- a/templates/_package.json.template
+++ b/templates/_package.json.template
@@ -12,7 +12,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node --import ./test/setup.js --test test/*.test.js",
+    "test": "node --import ./test/setup.js --test --test-concurrency=1 test/*.test.js",
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "prettier": "prettier --write .",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -276,6 +276,10 @@ test("settings validation supplies defaults for minimal configuration", () => {
     settings.config.find(({ name }) => name === "MONGODB_URL").value,
     "mongodb://127.0.0.1:27017/movies-api"
   );
+  assert.equal(
+    settings.config.find(({ name }) => name === "TEST_MONGODB_URL").value,
+    "mongodb://127.0.0.1:27017/movies-api-test"
+  );
 });
 
 test("models generate all CRUD routes by default", () => {
@@ -586,6 +590,10 @@ test("generators produce a clean src-based application without a DAL", async (t)
   );
   assert.match(environmentExample, /# MongoDB connection URL/);
   assert.match(environmentExample, /MONGODB_URL=/);
+  assert.match(
+    environmentExample,
+    /TEST_MONGODB_URL="mongodb:\/\/127\.0\.0\.1:27017\/movies-test"/
+  );
   assert.match(environmentExample, /JWT_KEY=\n/);
   assert.doesNotMatch(environmentExample, /JWT_KEY=.*change-me/);
 
@@ -594,6 +602,20 @@ test("generators produce a clean src-based application without a DAL", async (t)
     "utf8"
   );
   assert.match(generatedApp, /app\.use\(requestLogger\)/);
+
+  const testSetup = await readFile(
+    path.join(outputDirectory, "test/setup.js"),
+    "utf8"
+  );
+  assert.match(testSetup, /required\("TEST_MONGODB_URL"\)/);
+  assert.match(testSetup, /TEST_MONGODB_URL must differ from MONGODB_URL/);
+  assert.match(testSetup, /mongoose\.connection\.dropDatabase\(\)/);
+  assert.doesNotMatch(testSetup, /mongoose\.connect\(MONGODB_URL\)/);
+
+  const generatedPackage = JSON.parse(
+    await readFile(path.join(outputDirectory, "package.json"), "utf8")
+  );
+  assert.match(generatedPackage.scripts.test, /--test-concurrency=1/);
 
   const files = execFileSync("find", [outputDirectory, "-name", "*.js"], {
     encoding: "utf8"


### PR DESCRIPTION
- Use a dedicated database connection for generated application tests
- Prevent tests from falling back to or matching the application database
- Clean disposable test data safely after each test run
- Run generated test files serially to avoid database cleanup conflicts
- Document test database configuration and safety requirements
- Add coverage for generated test isolation safeguards

Closes #71