### PR TITLE
feat(generator): improve generated field validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,15 @@ You can generate an entire application by simply supplying a **json** settings f
       "attributes": [
         {
           "name": "[name of the attribute]",
-          "type": "[the data type of the attribute]",
+          "type": "[String, Number, Boolean, or Date]",
           "desc": "[a small description about the attribute]",
           "example": "[an example of the attribute]",
           "validation": [
-            { "type": "[based on Express Validator]" , "message": "[message to show when validation fails]"}
+            {
+              "type": "[supported validation rule]",
+              "message": "[message to show when validation fails]",
+              "args": [{"min": 2, "max": 100}]
+            }
           ],
           "isPrivate": "[indicates the attribute will not be returned, e.g. password (optional)]",
           "isAuto": "[indicates that the value for the attribute will be generated automatically]"
@@ -156,7 +160,24 @@ You can generate an entire application by simply supplying a **json** settings f
 }
 ```
 
-> Note: For details on the **Express Validator** validators, please look at its [documentation on GitHub](https://github.com/validatorjs/validator.js#validators).
+### Supported fields and validation
+
+Generated model fields support the common Mongoose scalar types `String`,
+`Number`, `Boolean`, and `Date`. Store uploaded-file URLs or external storage
+identifiers as strings; multipart upload handling is intentionally outside the
+generator's scope.
+
+The supported validation rules are:
+
+- `String`: `notEmpty`, `isString`, `isEmail`, `isURL`, and `isLength`
+- `Number`: `notEmpty`, `isNumeric`, `isInt`, and `isFloat`
+- `Boolean`: `notEmpty` and `isBoolean`
+- `Date`: `notEmpty` and `isISO8601`
+
+`isLength` requires one `args` object containing `min`, `max`, or both.
+`isInt` and `isFloat` accept an optional range object. Other rules do not
+accept arguments. Invalid types, rules, arguments, and incompatible
+field/rule combinations are rejected before generation begins.
 
 Here is a [Gist](https://gist.github.com/tsega/b15307af018d49171dfdbde47f0d2d07) with an example `settings.json` file.
 
@@ -200,7 +221,7 @@ Here is a [Gist](https://gist.github.com/tsega/b15307af018d49171dfdbde47f0d2d07)
           "desc": "",
           "example": "",
           "validation": [
-            { "type": "", "message": "" }
+            { "type": "notEmpty", "message": "This field is required" }
           ]
         }
       ]

--- a/cli/field-validation.js
+++ b/cli/field-validation.js
@@ -1,0 +1,101 @@
+export const FIELD_TYPES = ["String", "Number", "Boolean", "Date"];
+
+export const VALIDATION_RULES = {
+  notEmpty: { fieldTypes: FIELD_TYPES, arguments: "none" },
+  isString: { fieldTypes: ["String"], arguments: "none" },
+  isEmail: { fieldTypes: ["String"], arguments: "none" },
+  isURL: { fieldTypes: ["String"], arguments: "none" },
+  isLength: {
+    fieldTypes: ["String"],
+    arguments: "range-required",
+    wholeNumbers: true
+  },
+  isNumeric: { fieldTypes: ["Number"], arguments: "none" },
+  isInt: { fieldTypes: ["Number"], arguments: "range-optional" },
+  isFloat: { fieldTypes: ["Number"], arguments: "range-optional" },
+  isBoolean: { fieldTypes: ["Boolean"], arguments: "none" },
+  isISO8601: { fieldTypes: ["Date"], arguments: "none" }
+};
+
+export function getValidationIssue(fieldType, validation) {
+  const rule = VALIDATION_RULES[validation.type];
+  if (!rule) {
+    return `unsupported validation rule "${validation.type}"`;
+  }
+  if (!rule.fieldTypes.includes(fieldType)) {
+    return `validation rule "${validation.type}" is incompatible with field type "${fieldType}"`;
+  }
+
+  const args = validation.args;
+  if (rule.arguments === "none" && args.length > 0) {
+    return `validation rule "${validation.type}" does not accept arguments`;
+  }
+  if (rule.arguments === "range-required" && args.length !== 1) {
+    return `validation rule "${validation.type}" requires one range argument`;
+  }
+  if (rule.arguments === "range-optional" && args.length > 1) {
+    return `validation rule "${validation.type}" accepts at most one range argument`;
+  }
+  if (args.length === 1 && rule.arguments.startsWith("range")) {
+    return getRangeIssue(args[0], rule.wholeNumbers);
+  }
+
+  return null;
+}
+
+export function getInvalidValidationValue(validation) {
+  if (validation.type === "isBoolean") {
+    return "not-a-boolean";
+  }
+  if (["isNumeric", "isFloat"].includes(validation.type)) {
+    return "not-a-number";
+  }
+  if (validation.type === "isInt") {
+    return 1.5;
+  }
+  if (validation.type === "isISO8601") {
+    return "not-a-date";
+  }
+  if (validation.type === "isString") {
+    return 123;
+  }
+  if (validation.type === "isEmail") {
+    return "not-an-email";
+  }
+  if (validation.type === "isURL") {
+    return "not-a-url";
+  }
+  if (validation.type === "isLength") {
+    const { min, max } = validation.args[0];
+    return min > 0 ? "" : "x".repeat(max + 1);
+  }
+  return "";
+}
+
+function getRangeIssue(value, wholeNumbers = false) {
+  if (!isPlainObject(value)) {
+    return "range argument must be an object containing min or max";
+  }
+
+  const keys = Object.keys(value);
+  if (keys.length === 0 || keys.some((key) => !["min", "max"].includes(key))) {
+    return "range argument must contain only min or max";
+  }
+  if (keys.some((key) => typeof value[key] !== "number")) {
+    return "range argument min and max values must be numbers";
+  }
+  if (wholeNumbers && keys.some((key) => !Number.isInteger(value[key]) || value[key] < 0)) {
+    return "range argument min and max values must be non-negative integers";
+  }
+  if (value.min != null && value.max != null && value.min > value.max) {
+    return "range argument min cannot be greater than max";
+  }
+  if (wholeNumbers && value.max == null && value.min === 0) {
+    return "length range must define max or a positive min";
+  }
+  return null;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/cli/settings.js
+++ b/cli/settings.js
@@ -4,6 +4,11 @@ import path from "node:path";
 import { z } from "zod";
 
 import { ACTIONS } from "../config/index.js";
+import {
+  FIELD_TYPES,
+  getValidationIssue,
+  VALIDATION_RULES
+} from "./field-validation.js";
 
 const actionSchema = z.enum(ACTIONS);
 const configEntrySchema = z.object({
@@ -11,14 +16,21 @@ const configEntrySchema = z.object({
   value: z.union([z.string(), z.number(), z.boolean()]),
   comment: z.string().default("")
 });
+const validationArgumentSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+]);
 const attributeSchema = z.object({
   name: z.string().trim().min(1),
-  type: z.string().trim().min(1),
+  type: z.enum(FIELD_TYPES),
   desc: z.string().default(""),
   example: z.union([z.string(), z.number(), z.boolean()]).default(""),
   validation: z.array(z.object({
-    type: z.string().trim().min(1),
-    message: z.string().default("")
+    type: z.enum(Object.keys(VALIDATION_RULES)),
+    message: z.string().default(""),
+    args: z.array(validationArgumentSchema).default([])
   })).default([]),
   isPrivate: z.boolean().default(false),
   isAuto: z.boolean().default(false)
@@ -48,6 +60,25 @@ const settingsSchema = z.object({
   models: z.array(modelSchema).default([])
 }).superRefine((settings, context) => {
   settings.models.forEach((model, index) => {
+    model.attributes.forEach((attribute, attributeIndex) => {
+      attribute.validation.forEach((validation, validationIndex) => {
+        const issue = getValidationIssue(attribute.type, validation);
+        if (issue) {
+          context.addIssue({
+            code: "custom",
+            message: issue,
+            path: [
+              "models",
+              index,
+              "attributes",
+              attributeIndex,
+              "validation",
+              validationIndex
+            ]
+          });
+        }
+      });
+    });
     model.authentication.forEach((action) => {
       if (!model.routes.includes(action)) {
         context.addIssue({

--- a/generators/test.js
+++ b/generators/test.js
@@ -7,6 +7,7 @@ import clone from 'clone';
 import pluralize from 'pluralize';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { getInvalidValidationValue } from '../cli/field-validation.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -88,6 +89,11 @@ workflow.on('replaceTestTokens', function replaceTestTokens(models, currentModel
     testFile = testFile.replace(/\{\{authToken\}\}/g, appSettings.authentication
         ? '`Bearer ${jwt.sign({ sub: "test-user" }, JWT_KEY)}`'
         : '""');
+    testFile = testFile.replace(/\{\{validationTests\}\}/g, validationTests(currentModel));
+    testFile = testFile.replace(
+        /\{\{optionalValidationTest\}\}/g,
+        optionalValidationTest(currentModel)
+    );
 
     const routes = currentModel.routes ?? ["post", "get", "search", "put", "delete"];
     for (const action of ["post", "get", "search", "put", "delete"]) {
@@ -134,11 +140,51 @@ function modelFields(model) {
     let tokenReplacement = [];
 
     model.attributes.forEach(function (attribute) {
-        // TODO: check the output to be string or int
-        tokenReplacement.push("\t\t" + attribute.name + ":'" + attribute.example + "'");
+        tokenReplacement.push(`  ${JSON.stringify(attribute.name)}: ${JSON.stringify(attribute.example)}`);
     });
 
     return tokenReplacement.join(",\n") ;
+}
+
+function validationTests(model) {
+    const route = pluralize(model.name.toLowerCase());
+    const tests = [];
+
+    model.attributes.forEach(function (attribute) {
+        attribute.validation.forEach(function (validation) {
+            const invalidValue = JSON.stringify(getInvalidValidationValue(validation));
+            tests.push(`
+  it("rejects invalid ${attribute.name} values for ${validation.type}", async () => {
+    await request(app)
+      .post("/${route}")
+      .set("Authorization", authorization)
+      .send({ ...sampleDocument, ${JSON.stringify(attribute.name)}: ${invalidValue} })
+      .expect(422);
+  });`);
+        });
+    });
+
+    return tests.join("\n");
+}
+
+function optionalValidationTest(model) {
+    const hasValidation = model.attributes.some(
+        (attribute) => attribute.validation.length > 0
+    );
+    if (!hasValidation) {
+        return "";
+    }
+
+    return `
+  it("allows validated fields to be omitted when updating", async () => {
+    const existing = await ${model.name}.create(sampleDocument);
+
+    await request(app)
+      .put(\`/${pluralize(model.name.toLowerCase())}/\${existing.id}\`)
+      .set("Authorization", authorization)
+      .send({})
+      .expect(200);
+  });`;
 }
 
 /*

--- a/generators/validator.js
+++ b/generators/validator.js
@@ -144,9 +144,7 @@ function postFieldValidation(model) {
         // Validation based on setting
         if(attribute.validation) {
             attribute.validation.forEach(function(option) {
-                tokenReplacement += `
-                    body("${attribute.name}", "${option.message}")
-                        .${option.type}(),`;
+                tokenReplacement += validationExpression(attribute, option);
             });
         }
     });
@@ -171,15 +169,21 @@ function putFieldValidation(model) {
         let validatorList = attribute.validation.filter(o => !["isEmpty", "notEmpty"].includes(o.type));
 
         validatorList.forEach(function(option) {
-          tokenReplacement += `
-                body("${attribute.name}", "${option.message}")
-                  .optional()
-                  .${option.type}(),`;
+          tokenReplacement += validationExpression(attribute, option, true);
         });
       }
   });
 
   return tokenReplacement;
+}
+
+function validationExpression(attribute, option, optional = false) {
+  const args = option.args.map((argument) => JSON.stringify(argument)).join(", ");
+  const optionalCall = optional ? "\n                  .optional()" : "";
+
+  return `
+                body(${JSON.stringify(attribute.name)}, ${JSON.stringify(option.message)})${optionalCall}
+                  .${option.type}(${args}),`;
 }
 
 export function generate(settings, cb) {

--- a/templates/test.js.template
+++ b/templates/test.js.template
@@ -23,6 +23,7 @@ describe("{{modelName}} endpoints", () => {
 
     assert.ok(response.body._id);
   });
+{{validationTests}}
 {{/post}}
 {{#get}}
   it("gets a {{modelNameToLower}} by ID", async () => {
@@ -58,6 +59,7 @@ describe("{{modelName}} endpoints", () => {
 
     assert.equal(response.body._id, existing.id);
   });
+{{optionalValidationTest}}
 {{/put}}
 {{#delete}}
   it("deletes a {{modelNameToLower}}", async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -248,6 +248,71 @@ test("settings validation rejects unsupported authentication actions", () => {
   );
 });
 
+test("settings validation rejects unsupported field types and rules", () => {
+  const unsupportedType = createValidSettings();
+  unsupportedType.models[0].attributes[0].type = "Buffer";
+  assert.throws(
+    () => validateSettings(unsupportedType),
+    /attributes\.0\.type.*expected one of/
+  );
+
+  const unsupportedRule = createValidSettings();
+  unsupportedRule.models[0].attributes[0].validation = [
+    { type: "customValidator" }
+  ];
+  assert.throws(
+    () => validateSettings(unsupportedRule),
+    /validation\.0\.type.*expected one of/
+  );
+});
+
+test("settings validation rejects incompatible rules and invalid arguments", () => {
+  const incompatible = createValidSettings();
+  incompatible.models[0].attributes[0] = {
+    name: "rating",
+    type: "Number",
+    validation: [{ type: "isEmail" }]
+  };
+  assert.throws(
+    () => validateSettings(incompatible),
+    /isEmail.*incompatible with field type.*Number/i
+  );
+
+  const invalidArguments = createValidSettings();
+  invalidArguments.models[0].attributes[0].validation = [
+    { type: "isLength", args: [{ min: -1 }] }
+  ];
+  assert.throws(
+    () => validateSettings(invalidArguments),
+    /non-negative integers/
+  );
+
+  invalidArguments.models[0].attributes[0].validation = [
+    { type: "isLength", args: [{ min: 0 }] }
+  ];
+  assert.throws(
+    () => validateSettings(invalidArguments),
+    /must define max or a positive min/
+  );
+});
+
+test("settings validation accepts supported validator arguments", () => {
+  const settings = createValidSettings();
+  settings.models[0].attributes[0].validation = [
+    { type: "notEmpty", message: "Title is required" },
+    {
+      type: "isLength",
+      message: "Title must be 2 to 100 characters",
+      args: [{ min: 2, max: 100 }]
+    }
+  ];
+
+  const validated = validateSettings(settings);
+  assert.deepEqual(validated.models[0].attributes[0].validation[1].args, [
+    { min: 2, max: 100 }
+  ]);
+});
+
 test("settings loader accepts a valid relative path", async (t) => {
   const fixtureDirectory = await mkdtemp(
     path.join(tmpdir(), "restaculous-settings-test-")
@@ -521,6 +586,82 @@ test("route generator emits an ES module authentication import", async (t) => {
     /import \{ checkAuthToken \} from "\.\.\/middleware\/auth\.js";/
   );
   assert.doesNotMatch(route, /require\(/);
+});
+
+test("generators emit supported field validation and endpoint tests", async (t) => {
+  const outputDirectory = await mkdtemp(
+    path.join(tmpdir(), "restaculous-validation-test-")
+  );
+  t.after(() => rm(outputDirectory, { recursive: true, force: true }));
+  await mkdir(path.join(outputDirectory, "src", "routes", "validators"), {
+    recursive: true
+  });
+  await mkdir(path.join(outputDirectory, "test"), { recursive: true });
+
+  const settings = validateSettings({
+    name: "Movies",
+    directory: outputDirectory,
+    models: [
+      {
+        name: "Movie",
+        routes: ["post", "put"],
+        attributes: [
+          {
+            name: "title",
+            type: "String",
+            example: "Alien",
+            validation: [
+              { type: "notEmpty", message: "Title is required" },
+              { type: "isLength", args: [{ min: 2, max: 100 }] }
+            ]
+          },
+          {
+            name: "rating",
+            type: "Number",
+            example: 5,
+            validation: [{ type: "isInt" }]
+          },
+          {
+            name: "published",
+            type: "Boolean",
+            example: true,
+            validation: [{ type: "isBoolean" }]
+          },
+          {
+            name: "releasedAt",
+            type: "Date",
+            example: "1979-05-25",
+            validation: [{ type: "isISO8601" }]
+          }
+        ]
+      }
+    ]
+  });
+
+  await runGenerator(generateValidators, settings);
+  await runGenerator(generateTests, settings);
+
+  const validator = await readFile(
+    path.join(outputDirectory, "src/routes/validators/movie.js"),
+    "utf8"
+  );
+  assert.match(validator, /\.notEmpty\(\)/);
+  assert.match(validator, /\.isLength\(\{"min":2,"max":100\}\)/);
+  assert.match(validator, /\.optional\(\)\s+\.isLength/);
+  assert.match(validator, /\.isInt\(\)/);
+  assert.match(validator, /\.isBoolean\(\)/);
+  assert.match(validator, /\.isISO8601\(\)/);
+
+  const generatedTests = await readFile(
+    path.join(outputDirectory, "test/movie.test.js"),
+    "utf8"
+  );
+  assert.match(generatedTests, /rejects invalid title values for notEmpty/);
+  assert.match(generatedTests, /rejects invalid rating values for isInt/);
+  assert.match(generatedTests, /rejects invalid published values for isBoolean/);
+  assert.match(generatedTests, /rejects invalid releasedAt values for isISO8601/);
+  assert.match(generatedTests, /allows validated fields to be omitted when updating/);
+  execFileSync(process.execPath, ["--check", path.join(outputDirectory, "test/movie.test.js")]);
 });
 
 test("generators produce a clean src-based application without a DAL", async (t) => {


### PR DESCRIPTION
- Restrict models to supported Mongoose field types
- Validate configured rules and arguments before generation starts
- Prevent incompatible field and validation combinations
- Support range arguments for applicable validation rules
- Generate endpoint tests for required, optional, and type-specific validation
- Document supported fields, rules, and file-storage guidance
- Expand coverage for validation settings and generated output

Closes #70