### PR TITLE
test(generated-app): add authentication endpoint coverage

### DIFF
--- a/auth/test/auth.test.js
+++ b/auth/test/auth.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+
+import app from "../src/app.js";
+import { JWT_KEY } from "../src/config/index.js";
+
+let userNumber = 0;
+
+describe("authentication endpoints", () => {
+  it("registers a user without exposing their password", async () => {
+    const credentials = createCredentials();
+    const response = await register(credentials);
+
+    assert.equal(response.body.email, credentials.email);
+    assert.equal(response.body.password, undefined);
+    assert.ok(response.body._id);
+  });
+
+  it("rejects invalid registration fields", async () => {
+    const response = await request(app)
+      .post("/users")
+      .send({ email: "invalid", password: "short" })
+      .expect(422);
+
+    assert.ok(Array.isArray(response.body.errors));
+    assert.equal(response.body.errors.length, 2);
+  });
+
+  it("logs in a registered user and returns a token", async () => {
+    const credentials = createCredentials();
+    await register(credentials);
+
+    const response = await login(credentials);
+    assert.equal(response.body.message, "Authentication successful");
+    assert.equal(typeof response.body.token, "string");
+    assert.equal(
+      jwt.verify(response.body.token, JWT_KEY).email,
+      credentials.email
+    );
+  });
+
+  it("rejects invalid login credentials", async () => {
+    const credentials = createCredentials();
+    await register(credentials);
+
+    await request(app)
+      .post("/users/login")
+      .send({ ...credentials, password: "incorrect-password" })
+      .expect(401);
+  });
+
+  it("allows a valid token to access a protected endpoint", async () => {
+    const credentials = createCredentials();
+    await register(credentials);
+    const { body } = await login(credentials);
+
+    const response = await request(app)
+      .get("/users/search")
+      .set("Authorization", `Bearer ${body.token}`)
+      .expect(200);
+
+    assert.ok(Array.isArray(response.body.result));
+  });
+
+  it("rejects a missing authentication token", async () => {
+    await request(app).get("/users/me").expect(401);
+  });
+
+  it("rejects an invalid authentication token", async () => {
+    await request(app)
+      .get("/users/me")
+      .set("Authorization", "Bearer invalid-token")
+      .expect(401);
+  });
+
+  it("rejects an expired authentication token", async () => {
+    const token = jwt.sign({ sub: "expired-user" }, JWT_KEY, { expiresIn: -1 });
+
+    await request(app)
+      .get("/users/me")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(401);
+  });
+
+  it("returns the current user for a valid token", async () => {
+    const credentials = createCredentials();
+    await register(credentials);
+    const { body } = await login(credentials);
+
+    const response = await request(app)
+      .get("/users/me")
+      .set("Authorization", `Bearer ${body.token}`)
+      .expect(200);
+
+    assert.equal(response.body.email, credentials.email);
+    assert.equal(response.body.password, undefined);
+  });
+});
+
+function createCredentials() {
+  userNumber += 1;
+  return {
+    email: `generated-user-${userNumber}@example.com`,
+    password: "correct-horse-battery-staple"
+  };
+}
+
+function register(credentials) {
+  return request(app)
+    .post("/users")
+    .send(credentials)
+    .expect(201);
+}
+
+function login(credentials) {
+  return request(app)
+    .post("/users/login")
+    .send(credentials)
+    .expect(200);
+}

--- a/structure/README.md
+++ b/structure/README.md
@@ -46,3 +46,6 @@ Tests connect exclusively through `TEST_MONGODB_URL`; they never fall back to
 files run serially, and generated test data is removed from the test database
 before Mongoose disconnects. Always use a dedicated database because its data
 is intentionally disposable.
+
+When authentication is enabled, the generated suite also covers registration,
+login, protected routes, rejected tokens, and the current-user endpoint.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -588,6 +588,22 @@ test("route generator emits an ES module authentication import", async (t) => {
   assert.doesNotMatch(route, /require\(/);
 });
 
+test("authentication tests are generated only with authentication", async (t) => {
+  const outputDirectory = await mkdtemp(
+    path.join(tmpdir(), "restaculous-no-auth-test-")
+  );
+  t.after(() => rm(outputDirectory, { recursive: true, force: true }));
+
+  await runGenerator(generateStructure, {
+    directory: outputDirectory,
+    authentication: false
+  });
+
+  await assert.rejects(
+    readFile(path.join(outputDirectory, "test/auth.test.js"), "utf8")
+  );
+});
+
 test("generators emit supported field validation and endpoint tests", async (t) => {
   const outputDirectory = await mkdtemp(
     path.join(tmpdir(), "restaculous-validation-test-")
@@ -707,6 +723,7 @@ test("generators produce a clean src-based application without a DAL", async (t)
     "src/middleware/errors.js",
     "src/middleware/request-logger.js",
     "src/utils/logger.js",
+    "test/auth.test.js",
     "test/movie.test.js",
     ".env.example",
     "package.json"
@@ -757,6 +774,26 @@ test("generators produce a clean src-based application without a DAL", async (t)
     await readFile(path.join(outputDirectory, "package.json"), "utf8")
   );
   assert.match(generatedPackage.scripts.test, /--test-concurrency=1/);
+
+  const authenticationTests = await readFile(
+    path.join(outputDirectory, "test/auth.test.js"),
+    "utf8"
+  );
+  assert.match(authenticationTests, /registers a user/);
+  assert.match(authenticationTests, /rejects invalid registration fields/);
+  assert.match(
+    authenticationTests,
+    /logs in a registered user and returns a token/
+  );
+  assert.match(authenticationTests, /rejects invalid login credentials/);
+  assert.match(
+    authenticationTests,
+    /allows a valid token to access a protected endpoint/
+  );
+  assert.match(authenticationTests, /rejects a missing authentication token/);
+  assert.match(authenticationTests, /rejects an invalid authentication token/);
+  assert.match(authenticationTests, /rejects an expired authentication token/);
+  assert.match(authenticationTests, /returns the current user for a valid token/);
 
   const files = execFileSync("find", [outputDirectory, "-name", "*.js"], {
     encoding: "utf8"


### PR DESCRIPTION
- Generate authentication tests only when authentication is enabled
- Cover registration, validation, login, and token creation
- Verify protected routes with valid authentication
- Reject missing, invalid, and expired tokens
- Test current-user responses without exposing passwords
- Use Node.js’s built-in test runner and isolated test database
- Document and verify generated authentication coverage

Close #91