### PR TITLE
feat(generated-app): add health check endpoint

### DIFF
--- a/structure/README.md
+++ b/structure/README.md
@@ -13,6 +13,14 @@ npm start
 npm test
 ```
 
+## Health monitoring
+
+`GET /health` returns `{ "status": "ok" }` when the application process is
+running. It is public, contains no system or configuration details, and does
+not query MongoDB. This makes it suitable as a lightweight liveness check;
+database readiness should be monitored separately when a deployment requires
+it.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and provide values appropriate for the current

--- a/structure/src/app.js
+++ b/structure/src/app.js
@@ -3,11 +3,13 @@ import express from "express";
 import initializeRoutes from "./routes/index.js";
 import { errorHandler, notFoundHandler } from "./middleware/errors.js";
 import { requestLogger } from "./middleware/request-logger.js";
+import { healthCheck } from "./routes/health.js";
 
 const app = express();
 
 app.use(requestLogger);
 app.use(express.json());
+app.get("/health", healthCheck);
 initializeRoutes(app);
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/structure/src/routes/health.js
+++ b/structure/src/routes/health.js
@@ -1,0 +1,4 @@
+export function healthCheck(req, res) {
+  void req;
+  res.json({ status: "ok" });
+}

--- a/structure/test/health.test.js
+++ b/structure/test/health.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import request from "supertest";
+
+import app from "../src/app.js";
+
+describe("health endpoint", () => {
+  it("reports that the application process is running", async () => {
+    const response = await request(app).get("/health").expect(200);
+
+    assert.deepEqual(response.body, { status: "ok" });
+  });
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -719,11 +719,13 @@ test("generators produce a clean src-based application without a DAL", async (t)
     "src/controllers/movie.js",
     "src/models/movie.js",
     "src/routes/movie.js",
+    "src/routes/health.js",
     "src/services/auth.js",
     "src/middleware/errors.js",
     "src/middleware/request-logger.js",
     "src/utils/logger.js",
     "test/auth.test.js",
+    "test/health.test.js",
     "test/movie.test.js",
     ".env.example",
     "package.json"
@@ -760,6 +762,21 @@ test("generators produce a clean src-based application without a DAL", async (t)
     "utf8"
   );
   assert.match(generatedApp, /app\.use\(requestLogger\)/);
+  assert.match(generatedApp, /app\.get\("\/health", healthCheck\)/);
+
+  const healthRoute = await readFile(
+    path.join(outputDirectory, "src/routes/health.js"),
+    "utf8"
+  );
+  assert.match(healthRoute, /res\.json\(\{ status: "ok" \}\)/);
+  assert.doesNotMatch(healthRoute, /mongoose|MONGODB|process\.env/);
+
+  const healthTest = await readFile(
+    path.join(outputDirectory, "test/health.test.js"),
+    "utf8"
+  );
+  assert.match(healthTest, /get\("\/health"\)\.expect\(200\)/);
+  assert.match(healthTest, /deepEqual\(response\.body, \{ status: "ok" \}\)/);
 
   const testSetup = await readFile(
     path.join(outputDirectory, "test/setup.js"),


### PR DESCRIPTION
- Provide a public liveness endpoint for deployment monitoring
- Return a minimal response without exposing application details
- Keep health checks independent from MongoDB availability
- Include health requests in standard request logging
- Generate endpoint coverage using Node.js’s test runner
- Document health monitoring behavior and intended usage

Close #82